### PR TITLE
Don't validate external modules.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ gulp.task('test', [ 'jshint' ], function() {
 });
 
 gulp.task('jshint', function() {
-    return gulp.src([ '**/*.js', '!node_modules/**', '!public/**', '!data/**', '!demo/**' ])
+    return gulp.src([ '**/*.js', '!**/node_modules/**', '!public/**', '!data/**', '!demo/**' ])
         .pipe(plumber(function(error) {
             // Output error message
             gutil.log(gutil.colors.red(['Error (', error.plugin, '): ', error.message].join('')));


### PR DESCRIPTION
Example output:

$ gulp jshint
[06:54:26] Using gulpfile ~/workspace/americo/fork/apimock-1/gulpfile.js
[06:54:26] Starting 'jshint'...
[06:54:26] 'test' api.js 1.83 kB
[06:54:26] 'test' disposable.js 816 B
[06:54:27] 'test' folders.js 715 B
[06:54:27] 'test' gulpfile.js 2.2 kB
[06:54:27] 'test' logger.js 1.52 kB
[06:54:28] 'test' message-queue.js 1.74 kB
[06:54:28] 'test' server.js 1.61 kB
[06:54:28] 'test' api/comparator.js 2.67 kB
[06:54:28] 'test' api/folders.js 1.69 kB
[06:54:28] 'test' api/get.js 8.36 kB
[06:54:28] 'test' api/overriders.js 7.76 kB
[06:54:28] 'test' api/post.js 9.96 kB
[06:54:28] 'test' test/spec-api-folders.js 3.48 kB
[06:54:28] 'test' test/spec-api.js 1.63 kB
[06:54:28] 'test' test/spec-disposable.js 1.94 kB
[06:54:28] 'test' test/spec-message-queue.js 1.85 kB
[06:54:28] 'test' all files 49.77 kB
[06:54:28] Finished 'jshint' after 2.27 s
